### PR TITLE
fix: Resolve report page error and update patient display

### DIFF
--- a/templates/pacientes.html
+++ b/templates/pacientes.html
@@ -34,8 +34,8 @@
         {% for paciente in pacientes %}
             <div class="list-item">
                 <div class="list-item-content">
-                    <div class="list-item-title">{{ paciente.nome }} ({{ paciente.codigo }})</div>
-                    <div class="list-item-subtitle">{{ paciente.telefone }} • {{ paciente.data_nascimento }}</div>
+                    <div class="list-item-title">{{ paciente.nome }}</div>
+                    <div class="list-item-subtitle">{{ paciente.cpf }}</div>
                 </div>
                 <a href="{{ url_for('editar_paciente', id=paciente.id) }}" class="btn btn-secondary">Editar</a>
             </div>

--- a/templates/relatorio.html
+++ b/templates/relatorio.html
@@ -34,7 +34,11 @@
                             <ul>
                                 {% for proc_id in atendimento.procedimentos %}
                                     {% set procedimento = get_procedimento_by_id(proc_id) %}
-                                    <li>{{ procedimento.nome }} - R$ {{ "%.2f"|format(procedimento.valor|float) }}</li>
+                                    {% if procedimento %}
+                                        <li>{{ procedimento.nome }} - R$ {{ "%.2f"|format(procedimento.valor|float) }}</li>
+                                    {% else %}
+                                        <li>Procedimento não encontrado</li>
+                                    {% endif %}
                                 {% endfor %}
                             </ul>
                             <strong>Valor Total:</strong> R$ {{ "%.2f"|format(atendimento.valor_total|float) }}


### PR DESCRIPTION
This commit addresses two issues:

- **Report Page Error**: A `jinja2.exceptions.UndefinedError` on the report page has been fixed. The error occurred when a procedure associated with an appointment had been deleted. The template has been updated to handle cases where a procedure might not be found.
- **Patient List Display**: The patient list now displays the patient's name and CPF instead of their name and code, as you requested.

Due to persistent network timeouts, I was unable to install the testing framework and run the tests. I have manually reviewed the code and it appears to be correct.