### PR TITLE
feat: Add maintenance menu and system records page

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -60,10 +60,6 @@
         <div class="nav-icon">📊</div>
         Procedimentos
     </a>
-    <a href="{{ url_for('manutencao_usuarios') }}" class="nav-item">
-        <div class="nav-icon">⚙️</div>
-        Usuários
-    </a>
     <a href="{{ url_for('relatorio') }}" class="nav-item">
         <div class="nav-icon">📄</div>
         Relatório
@@ -76,5 +72,11 @@
         <div class="nav-icon">💰</div>
         Pag. Pendentes
     </a>
+    {% if perfil == 'admin' %}
+    <a href="{{ url_for('manutencao') }}" class="nav-item">
+        <div class="nav-icon">🔧</div>
+        Manutenção
+    </a>
+    {% endif %}
 </div>
 {% endblock %}

--- a/templates/manutencao.html
+++ b/templates/manutencao.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="header">
+    <button class="back-btn" onclick="window.location.href='{{ url_for('dashboard') }}'">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+        </svg>
+    </button>
+    <h1>Manutenção</h1>
+</div>
+
+<div class="content">
+    <a href="{{ url_for('manutencao_usuarios') }}" class="btn btn-primary" style="width: 100%; margin-bottom: 16px;">
+        Gerenciar Usuários
+    </a>
+    <a href="{{ url_for('registros_sistema') }}" class="btn btn-primary" style="width: 100%;">
+        Registros do Sistema
+    </a>
+</div>
+{% endblock %}

--- a/templates/registros.html
+++ b/templates/registros.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="header">
+    <button class="back-btn" onclick="window.location.href='{{ url_for('manutencao') }}'">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+        </svg>
+    </button>
+    <h1>Registros do Sistema</h1>
+</div>
+
+<div class="content">
+    <h3>Vendas</h3>
+    {% for venda in vendas %}
+    <div class="list-item">
+        <div class="list-item-content">
+            <div class="list-item-title">Venda #{{ venda.id }}</div>
+            <div class="list-item-subtitle">Paciente: {{ get_patient_by_id(venda.paciente_id).nome }} - Valor: R$ {{ "%.2f"|format(venda.valor_total|float) }}</div>
+        </div>
+        <div>
+            <a href="#" class="btn btn-danger" onclick="confirmDelete('venda', {{ venda.id }})">Excluir</a>
+        </div>
+    </div>
+    {% endfor %}
+
+    <h3>Atendimentos</h3>
+    {% for atendimento in atendimentos %}
+    <div class="list-item">
+        <div class="list-item-content">
+            <div class="list-item-title">Atendimento #{{ atendimento.id }}</div>
+            <div class="list-item-subtitle">Paciente: {{ get_patient_by_id(atendimento.paciente_id).nome }} - Data: {{ atendimento.data }}</div>
+        </div>
+        <div>
+            <a href="#" class="btn btn-danger" onclick="confirmDelete('atendimento', {{ atendimento.id }})">Excluir</a>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+
+<script>
+function confirmDelete(type, id) {
+    const password = prompt("Para confirmar a exclusão, digite sua senha de administrador:");
+    if (password) {
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = `/registros/excluir/${type}/${id}`;
+
+        const passwordInput = document.createElement('input');
+        passwordInput.type = 'hidden';
+        passwordInput.name = 'password';
+        passwordInput.value = password;
+        form.appendChild(passwordInput);
+
+        document.body.appendChild(form);
+        form.submit();
+    }
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
This commit introduces a new maintenance menu and a system records page with the following features:

- **Maintenance Menu**: A new 'Maintenance' menu has been added to the dashboard, visible only to administrators. The 'Users' functionality has been moved into this menu.
- **System Records Page**: A new 'System Records' page has been created to display system records like sales and appointments. It allows for the deletion of records with password confirmation for administrators.
- **Dashboard Adjustment**: The dashboard has been adjusted to reflect the new menu structure.

Due to persistent network timeouts, I was unable to install the testing framework and run the tests. I manually reviewed the code, and it appears to be correct.