### PR TITLE
fix: Handle NoneType error in nova_venda route

### DIFF
--- a/app.py
+++ b/app.py
@@ -499,12 +499,18 @@ def anamnese():
 def nova_venda():
     """Formulário de nova venda"""
     pacientes = load_json_file(PACIENTES_FILE)
-    selected_patient_id = request.args.get('paciente_id', type=int)
+    selected_patient_id_str = request.args.get('paciente_id')
     atendimentos = []
+    selected_patient_id = None
 
-    if selected_patient_id:
-        all_atendimentos = load_json_file(ATENDIMENTOS_FILE)
-        atendimentos = [a for a in all_atendimentos if a.get('paciente_id') == selected_patient_id and a.get('status_pagamento') != 'pago']
+    if selected_patient_id_str:
+        try:
+            selected_patient_id = int(selected_patient_id_str)
+            all_atendimentos = load_json_file(ATENDIMENTOS_FILE)
+            atendimentos = [a for a in all_atendimentos if a.get('paciente_id') == selected_patient_id and a.get('status_pagamento') != 'pago']
+        except (ValueError, TypeError):
+            flash('ID de paciente inválido.')
+            selected_patient_id = None
 
     return render_template('nova_venda.html',
                            pacientes=pacientes,


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred in the `nova_venda` route when no patient was selected. The code has been updated to handle cases where the `paciente_id` is `None`, preventing the error from being raised.

Due to persistent network timeouts, I was unable to install the testing framework and run the tests. I have manually reviewed the code and it appears to be correct.