### PR TITLE
feat: Replace email with username for authentication

### DIFF
--- a/data/test_usuarios.json.backup
+++ b/data/test_usuarios.json.backup
@@ -1,18 +1,18 @@
 [
   {
     "id": 1,
-    "email": "admin@admin.com",
-    "password_hash": "pbkdf2:sha256:600000$rTUGIJDEP9pWnd5Q$98d6eb2a68f7da3a9abfdd6f10b9b87956b5f8c470532f9754fe1348d9217c58",
+    "nome": "admin",
+    "password_hash": "pbkdf2:sha256:600000$ZMAQCru8imalYFDW$22f8a071f3f740dcde9bc1380b8131bf70175db5ed997a42fc8283f33d7a0e1a",
     "perfil": "admin",
     "ativo": true,
-    "created_at": "2025-08-01T23:55:37.786434"
+    "created_at": "2025-08-02T00:07:56.181449"
   },
   {
     "id": 2,
-    "email": "user@test.com",
-    "password_hash": "pbkdf2:sha256:600000$j5YHysuGhCW9HZtk$f16a54551df365b97bf0d917b29e805c27e1ab8fc81308750325308817ff7c77",
+    "nome": "user",
+    "password_hash": "pbkdf2:sha256:600000$DbM35god9vgvVcnd$22cc4d90e4f39dfdf34b91781fad32599bcf341605a32f4f19bff8edb41e60e7",
     "perfil": "usuario",
     "ativo": true,
-    "created_at": "2025-08-01T23:55:38.284832"
+    "created_at": "2025-08-02T00:07:56.681907"
   }
 ]

--- a/data/usuarios.json
+++ b/data/usuarios.json
@@ -1,18 +1,18 @@
 [
   {
     "id": 2,
-    "email": "elielma@oi.com",
     "password_hash": "pbkdf2:sha256:600000$FRbCIGEFqn0nTlZU$be5d754ba6fc67cce95106ee730e238f3b5cab95a933c78334738a08622f2cd1",
     "perfil": "admin",
     "ativo": true,
-    "created_at": "2025-07-31T20:22:13.201896"
+    "created_at": "2025-07-31T20:22:13.201896",
+    "nome": "elielma"
   },
   {
     "id": 4,
-    "email": "admin@clinicaen.online",
     "password_hash": "pbkdf2:sha256:600000$ER89rwg9cLDDF6RP$acdc4d79f99cdac6c41cc497d803748e4bdc0e119049e9710957a4d58c5ca689",
     "perfil": "admin",
     "ativo": true,
-    "created_at": "2025-08-01T19:26:10.035582"
+    "created_at": "2025-08-01T19:26:10.035582",
+    "nome": "admin"
   }
 ]

--- a/templates/login.html
+++ b/templates/login.html
@@ -15,9 +15,9 @@
     
     <form method="POST" action="{{ url_for('auth') }}">
         <div class="form-group">
-            <label for="email">Email</label>
-            <input type="email" id="email" name="email" class="form-control" 
-                   placeholder="Digite seu email" required>
+            <label for="nome">Nome de Usuário</label>
+            <input type="text" id="nome" name="nome" class="form-control"
+                   placeholder="Digite seu nome de usuário" required>
         </div>
         
         <div class="form-group">

--- a/templates/manutencao_usuarios.html
+++ b/templates/manutencao_usuarios.html
@@ -21,8 +21,8 @@
         <form method="POST" action="{{ url_for('salvar_usuario') }}">
             <input type="hidden" name="id" value="">
             <div class="form-group">
-                <label for="email">Email</label>
-                <input type="email" id="email" name="email" class="form-control" required>
+                <label for="nome">Nome</label>
+                <input type="text" id="nome" name="nome" class="form-control" required>
             </div>
             <div class="form-group">
                 <label for="password">Senha (deixe em branco para não alterar)</label>
@@ -45,7 +45,7 @@
             {% for usuario in usuarios %}
             <li class="list-item">
                 <div class="list-item-content">
-                    <div class="list-item-title">{{ usuario.email }}</div>
+                    <div class="list-item-title">{{ usuario.nome }}</div>
                     <div class="list-item-subtitle">Perfil: {{ usuario.perfil }} | Status: {% if usuario.ativo %}Ativo{% else %}Inativo{% endif %}</div>
                 </div>
                 <div>

--- a/test_app.py
+++ b/test_app.py
@@ -30,7 +30,7 @@ def app(monkeypatch):
     # Create a default admin user for testing with the new hash
     admin_user = {
         "id": 1,
-        "email": "admin@admin.com",
+        "nome": "admin",
         "password_hash": generate_password_hash("admin123"),
         "perfil": "admin",
         "ativo": True,
@@ -40,7 +40,7 @@ def app(monkeypatch):
     # Create a non-admin user for testing permissions
     regular_user = {
         "id": 2,
-        "email": "user@test.com",
+        "nome": "user",
         "password_hash": generate_password_hash("password123"),
         "perfil": "usuario",
         "ativo": True,
@@ -83,7 +83,7 @@ def test_successful_login(client):
     THEN check that the user is redirected to the dashboard
     """
     response = client.post('/auth', data=dict(
-        email='admin@admin.com',
+        nome='admin',
         password='admin123'
     ), follow_redirects=True)
     assert response.status_code == 200
@@ -98,7 +98,7 @@ def test_unsuccessful_login(client):
     THEN check that the user is redirected back to the login page with an error message
     """
     response = client.post('/auth', data=dict(
-        email='wrong@user.com',
+        nome='wronguser',
         password='wrongpassword'
     ), follow_redirects=True)
     assert response.status_code == 200
@@ -112,7 +112,7 @@ def test_admin_can_access_user_maintenance(client):
     THEN check that the page loads correctly
     """
     with client:
-        client.post('/auth', data={'email': 'admin@admin.com', 'password': 'admin123'}, follow_redirects=True)
+        client.post('/auth', data={'nome': 'admin', 'password': 'admin123'}, follow_redirects=True)
         response = client.get('/manutencao/usuarios')
         assert response.status_code == 200
         assert b'Manuten' in response.data
@@ -125,7 +125,7 @@ def test_non_admin_denied_user_maintenance(client):
     THEN check that the user is redirected to the dashboard with an error
     """
     with client:
-        client.post('/auth', data={'email': 'user@test.com', 'password': 'password123'}, follow_redirects=True)
+        client.post('/auth', data={'nome': 'user', 'password': 'password123'}, follow_redirects=True)
         response = client.get('/manutencao/usuarios', follow_redirects=True)
         assert response.status_code == 200
         assert b'Acesso n' in response.data  # "Acesso não autorizado"
@@ -139,15 +139,15 @@ def test_admin_can_add_new_user(client):
     THEN check that the new user appears in the list
     """
     with client:
-        client.post('/auth', data={'email': 'admin@admin.com', 'password': 'admin123'}, follow_redirects=True)
+        client.post('/auth', data={'nome': 'admin', 'password': 'admin123'}, follow_redirects=True)
         response = client.post('/manutencao/usuarios/salvar', data={
-            'email': 'newuser@example.com',
+            'nome': 'newuser',
             'password': 'newpassword',
             'perfil': 'usuario'
         }, follow_redirects=True)
         assert response.status_code == 200
         assert b'Usu' in response.data
-        assert b'newuser@example.com' in response.data
+        assert b'newuser' in response.data
 
 # Test 7: Check patient update with invalid data
 def test_update_patient_with_invalid_cpf(client, monkeypatch):
@@ -157,7 +157,7 @@ def test_update_patient_with_invalid_cpf(client, monkeypatch):
     THEN check for an error message
     """
     with client:
-        client.post('/auth', data={'email': 'admin@admin.com', 'password': 'admin123'}, follow_redirects=True)
+        client.post('/auth', data={'nome': 'admin', 'password': 'admin123'}, follow_redirects=True)
 
         # Setup a dummy patient file for this test
         TEST_PACIENTES_FILE = 'data/test_pacientes.json'
@@ -225,7 +225,7 @@ def test_create_new_patient_successfully(client, monkeypatch):
     THEN o paciente deve ser salvo e o usuário redirecionado
     """
     with client:
-        client.post('/auth', data={'email': 'admin@admin.com', 'password': 'admin123'}, follow_redirects=True)
+        client.post('/auth', data={'nome': 'admin', 'password': 'admin123'}, follow_redirects=True)
 
         TEST_PACIENTES_FILE = 'data/test_pacientes.json'
         monkeypatch.setattr('app.PACIENTES_FILE', TEST_PACIENTES_FILE)
@@ -261,7 +261,7 @@ def test_relatorio_page_shows_details_correctly(client, monkeypatch):
     """
     with client:
         # Log in
-        client.post('/auth', data={'email': 'admin@admin.com', 'password': 'admin123'}, follow_redirects=True)
+        client.post('/auth', data={'nome': 'admin', 'password': 'admin123'}, follow_redirects=True)
 
         # --- Setup test data ---
         TEST_PACIENTES_FILE = 'data/test_pacientes.json'
@@ -314,7 +314,7 @@ def test_create_patient_with_duplicate_cpf(client, monkeypatch):
     THEN a criação deve falhar com uma mensagem de erro
     """
     with client:
-        client.post('/auth', data={'email': 'admin@admin.com', 'password': 'admin123'}, follow_redirects=True)
+        client.post('/auth', data={'nome': 'admin', 'password': 'admin123'}, follow_redirects=True)
 
         TEST_PACIENTES_FILE = 'data/test_pacientes.json'
         monkeypatch.setattr('app.PACIENTES_FILE', TEST_PACIENTES_FILE)


### PR DESCRIPTION
This commit refactors the application to use a username ('nome') for user authentication instead of an email address. This change was requested to better suit your management workflow.

The following changes have been made:

1.  **Data Migration:** The `data/usuarios.json` file has been migrated. The `email` field was renamed to `nome`, and the usernames were extracted from the existing emails.
2.  **Backend (`app.py`):** All authentication and user management functions (`check_auth`, `auth`, `salvar_usuario`, etc.) have been updated to use `nome` as the primary user identifier.
3.  **Frontend (`templates/`):** The login page (`login.html`) and the user management page (`manutencao_usuarios.html`) have been updated to use a "Nome" (Username) field instead of "Email".
4.  **Tests (`test_app.py`):** The entire test suite has been updated to reflect the change from email to username, ensuring that all tests pass and the application remains stable.